### PR TITLE
Initial trial of perplexity

### DIFF
--- a/dlm/io/lmDatasetReader.py
+++ b/dlm/io/lmDatasetReader.py
@@ -17,9 +17,9 @@ class LMDatasetReader(reader.Reader):
 		
 		# Reading parameters from the mmap file
 		fp = np.memmap(dataset_path, dtype='int32', mode='r')
-		self.num_samples = fp[0]							
-		self.ngram = fp[1]									
-		self.num_word_types = fp[2]						
+		self.num_samples = fp[0]
+		self.ngram = fp[1]
+		self.num_word_types = fp[2]
 
 		# Setting minibatch size and number of mini batches
 		self.batch_size = batch_size					

--- a/dlm/io/lmDatasetReader.py
+++ b/dlm/io/lmDatasetReader.py
@@ -22,11 +22,11 @@ class LMDatasetReader(reader.Reader):
 		self.num_word_types = fp[2]
 
 		# Setting minibatch size and number of mini batches
-		self.batch_size = batch_size					
+		self.batch_size = batch_size	
 		self.num_batches = int(M.ceil(self.num_samples / batch_size))
 		
 		# Reading the matrix of samples
-		fp = fp.reshape((self.num_samples + 1, self.ngram))	
+		fp = fp.reshape((self.num_samples + 1, self.ngram))
 		x = fp[1:,0:self.ngram - 1]			# Reading the context indices
 		y = fp[1:,self.ngram - 1]			# Reading the output word index
 		self.shared_x = T.cast(theano.shared(x, borrow=True), 'int32')

--- a/dlm/io/lmDatasetReader.py
+++ b/dlm/io/lmDatasetReader.py
@@ -14,15 +14,21 @@ class LMDatasetReader(reader.Reader):
 	def __init__(self, dataset_path, batch_size=10):
 		
 		print "Initializing dataset from: " + dataset_path
+		
+		# Reading parameters from the mmap file
 		fp = np.memmap(dataset_path, dtype='int32', mode='r')
-		self.num_samples = fp[0]
-		self.ngram = fp[1]
-		self.num_word_types = fp[2]
-		self.batch_size = batch_size
-		fp = fp.reshape((self.num_samples + 1, self.ngram))
-		x = fp[1:,0:self.ngram - 1]
-		y = fp[1:,self.ngram - 1]
+		self.num_samples = fp[0]							
+		self.ngram = fp[1]									
+		self.num_word_types = fp[2]						
+
+		# Setting minibatch size and number of mini batches
+		self.batch_size = batch_size					
 		self.num_batches = int(M.ceil(self.num_samples / batch_size))
+		
+		# Reading the matrix of samples
+		fp = fp.reshape((self.num_samples + 1, self.ngram))	
+		x = fp[1:,0:self.ngram - 1]			# Reading the context indices
+		y = fp[1:,self.ngram - 1]			# Reading the output word index
 		self.shared_x = T.cast(theano.shared(x, borrow=True), 'int32')
 		self.shared_y = T.cast(theano.shared(y, borrow=True), 'int32')
 		print "Dataset initialized"

--- a/train.py
+++ b/train.py
@@ -84,6 +84,16 @@ def test_mlp(trainset, devset, testset, learning_rate=0.01, L1_reg=0.00, L2_reg=
 		}
 	)
 
+	dev_negative_log_likelihood = theano.function(
+		inputs=[index],
+		outputs=classifier.negative_log_likelihood(y),
+		givens={
+			x: devset.get_x(index),
+			y: devset.get_y(index)
+		}
+	)
+
+
 	print '... training'
 
 	patience = 10000											# look as this many examples regardless
@@ -118,13 +128,17 @@ def test_mlp(trainset, devset, testset, learning_rate=0.01, L1_reg=0.00, L2_reg=
 				validation_losses = [validate_model(i) for i in xrange(n_dev_batches)]
 				this_validation_loss = numpy.mean(validation_losses)
 
+				sum_dev_likelihood = sum([dev_negative_log_likelihood(i) for i in xrange(n_dev_batches)])
+				dev_perplexity = sum_dev_likelihood / n_dev_batches
+
 				print(
-					'epoch %i, minibatch %i/%i, validation error %f %%' %
+					'epoch %i, minibatch %i/%i, validation error %f %% , perplexity %f' %
 					(
 						epoch,
 						minibatch_index + 1,
 						n_train_batches,
-						this_validation_loss * 100.
+						this_validation_loss * 100.,
+						dev_perplexity
 					)
 				)
 

--- a/train.py
+++ b/train.py
@@ -8,6 +8,7 @@ import numpy
 import theano
 import theano.tensor as T
 import time
+import math
 
 from dlm.io.lmDatasetReader import LMDatasetReader
 from dlm.io.irisDatasetReader import IRISDatasetReader
@@ -128,8 +129,8 @@ def test_mlp(trainset, devset, testset, learning_rate=0.01, L1_reg=0.00, L2_reg=
 				validation_losses = [validate_model(i) for i in xrange(n_dev_batches)]
 				this_validation_loss = numpy.mean(validation_losses)
 
-				sum_dev_likelihood = sum([dev_negative_log_likelihood(i) for i in xrange(n_dev_batches)])
-				dev_perplexity = sum_dev_likelihood / n_dev_batches
+				dev_sum_neg_likelihood = sum([dev_negative_log_likelihood(i) for i in xrange(n_dev_batches)])
+				dev_perplexity = math.exp(dev_sum_neg_likelihood / n_dev_batches)
 
 				print(
 					'epoch %i, minibatch %i/%i, validation error %f %% , perplexity %f' %


### PR DESCRIPTION
This is what I think I did.
Using classifier log likelihood function to get the mean negative log likelihood of the minibatch.
Sum the mean negative likelihood of all the minibatches.
Divide by the number of minibatches to get the total mean negative log likelihood.
Exp( of this value) = perplexity.

perplexity = exp(sum(loglikelihood of all samples)/#samples) 
Checked NPLM code...
log_likelihood += minibatch_log_likelihood;
.
.
 cerr << "           perplexity:     "<< exp(-log_likelihood/validation_data_size) << endl


